### PR TITLE
Add the 400 weight Source Sans Pro here

### DIFF
--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -6,7 +6,7 @@
 
 /* comment the following line and uncomment the next but one to use fonts with the google api */
 @import 'fonts.css';
-/* @import url('http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,700,900'); */
+/* @import url('http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700,900'); */
 
 /*
 	Phantom by HTML5 UP


### PR DESCRIPTION
We're using the 400 weight in fonts.css, just lining up the google fonts api so it's the same.